### PR TITLE
add simple class instantiation

### DIFF
--- a/scrollReveal.js
+++ b/scrollReveal.js
@@ -25,6 +25,9 @@ window.scrollReveal = (function( window ){
   var self;
 
   function scrollReveal( config ){
+    if (!(this instanceof scrollReveal)) {
+      return new scrollReveal(config);
+    }
 
     self         = this;
     self.elems   = {};


### PR DESCRIPTION
@julianlloyd

Simple class instantiation can be useful depending on how you are composing your application structure. In cases where a `ScrollReveal` constructor reference is not needed, it is convenient to `require("scrollreveal")({ options })` in just one line.

###### tl;dr 
This little change allows me to compose my requires (front-end project using browserify) more neatly.
